### PR TITLE
Update treeTable.js

### DIFF
--- a/treeTable.js
+++ b/treeTable.js
@@ -223,6 +223,11 @@ var com_github_culmat_jsTreeTable =  (function(){
 				this.trChildrenVisible ? this.trCollapse(true) : this.trExpand(true)
 			})
 		})
+
+		$("tr[data-tt-collapsed]", table).each(function(index, tr) {
+			$(tr).trigger('click');
+		});
+
 		return table
 	}
 	


### PR DESCRIPTION
Added attribute data-tt-collapsed to allow to set nodes to collapsed state.
Just add this attribute to a table row (value is currently not evaluated) to collapse the tree node